### PR TITLE
Add executable path to settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "editor.suggest.snippetsPreventQuickSuggestions": false,
+    "satysfi-workshop.executable": "/home/gitpod/.opam/4.14.1/bin/satysfi",
     "satysfi-workshop.languageServer.enabled": true
 }


### PR DESCRIPTION
For unknown reasons, it seems that the PATH is not being read correctly, so I decided to manually specify the path to the `satysfi` binary.