### PR TITLE
Update extension for pdf preview

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,4 +8,4 @@ ports:
 vscode:
   extensions:
     - pickoba.satysfi-workshop
-    - tomoki1207.pdf
+    - james-yu.latex-workshop

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Click the button below to start a new environment:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/pickoba/satysfi-gitpod-template/blob/main/document.saty)
 
-**Note**: It appears that the pdf viewer ([tomoki1207.pdf](https://marketplace.visualstudio.com/items?itemName=tomoki1207.pdf)) is currently unavailable from Gitpod in the browser. Therefore, I recommend that you use VS Code in your local environment by following the steps below.
+If you want to use VS Code in your local environment, follow the steps below.
 
 1. Open Gitpod in your browser using the button above
 2. Open the command palette by pressing "Ctrl/Cmd+Shift+P"


### PR DESCRIPTION
Since LaTeX Workshop is the most stable PDF viewer available on Gitpod, I decided to use it instead of `tomoki1207.pdf`.